### PR TITLE
Changes and fixes in handling of .NET reference assemblies

### DIFF
--- a/DotNetEditor/App.config
+++ b/DotNetEditor/App.config
@@ -53,6 +53,10 @@
         <assemblyIdentity name="System.Composition.Hosting" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.0.30.0" newVersion="1.0.30.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/DotNetEditor/CodeRunner/CSCodeRunner.cs
+++ b/DotNetEditor/CodeRunner/CSCodeRunner.cs
@@ -28,10 +28,20 @@ namespace DotNetEditor.CodeRunner
             uniqueImports.Add("mscorlib.dll");
             uniqueImports.Add("Microsoft.CSharp.dll");
 
-            string dllPath = GetReferenceAssembliesPath();
-            IEnumerable<MetadataReference> references =
-                uniqueImports.Select(import => MetadataReference.CreateFromFile(
-                    System.IO.Path.Combine(dllPath, import)));
+            List<MetadataReference> references = new List<MetadataReference>();
+            try
+            {
+                string dllPath = GetReferenceAssembliesPath();
+                foreach (string import in uniqueImports)
+                {
+                    references.Add(MetadataReference.CreateFromFile(System.IO.Path.Combine(
+                                                                        dllPath, import)));
+                }
+            }
+            catch (Exception e)
+            {
+                throw new CodeRunnerException(e.Message, e);
+            }
 
             var options = new CSharpCompilationOptions(OutputKind.ConsoleApplication);
 

--- a/DotNetEditor/CodeRunner/CodeRunnerBase.cs
+++ b/DotNetEditor/CodeRunner/CodeRunnerBase.cs
@@ -115,7 +115,29 @@ namespace DotNetEditor.CodeRunner
         // Return: whether a the code runs successfully without error.
         protected string GetReferenceAssembliesPath()
         {
-            return @"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.1";
+            string basepath = System.IO.Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86,
+                                          Environment.SpecialFolderOption.DoNotVerify),
+                "Reference Assemblies",
+                "Microsoft",
+                "Framework",
+                ".NETFramework");
+
+            // Return the newest version with version number 4.6.x.
+            string[] directories = System.IO.Directory.GetDirectories(basepath, "v4.6.*");
+            if (directories.Any()) {
+                return directories.Max();
+            }
+
+            // If not found, return the newest version with version number 4.x.
+            directories = System.IO.Directory.GetDirectories(basepath, "v4.*");
+            if (directories.Any())
+            {
+                return directories.Max();
+            }
+
+            // If still not found, throw an exception.
+            throw new System.IO.DirectoryNotFoundException("Cannot locate a v4.x .NET framework.");
         }
 
         protected abstract Compilation GetCompilation();

--- a/DotNetEditor/CodeRunner/CodeRunnerBase.cs
+++ b/DotNetEditor/CodeRunner/CodeRunnerBase.cs
@@ -134,7 +134,7 @@ namespace DotNetEditor.CodeRunner
                 if (directories.Any())
                 {
                     // If multiple versions are found, return the path to the latest version.
-                    //return directories.Max();
+                    return directories.Max();
                 }
             }
 

--- a/DotNetEditor/CodeRunner/CodeRunnerException.cs
+++ b/DotNetEditor/CodeRunner/CodeRunnerException.cs
@@ -1,0 +1,16 @@
+﻿// Copyright 2017 Leung Wing-chung. All rights reserved.
+// Use of this source code is governed by a GPLv3 license that can be found in
+// the LICENSE file.
+
+using System;
+
+namespace DotNetEditor.CodeRunner
+{
+    [Serializable]
+    class CodeRunnerException : Exception
+    {
+        public CodeRunnerException() { }
+        public CodeRunnerException(string message) : base(message) { }
+        public CodeRunnerException(string message, Exception e) : base(message, e) { }
+    }
+}

--- a/DotNetEditor/CodeRunner/VBCodeRunner.cs
+++ b/DotNetEditor/CodeRunner/VBCodeRunner.cs
@@ -32,10 +32,20 @@ namespace DotNetEditor.CodeRunner
             uniqueImports.Add("mscorlib.dll");
             uniqueImports.Add("Microsoft.VisualBasic.dll");
 
-            string dllPath = GetReferenceAssembliesPath();
-            IEnumerable<MetadataReference> references =
-                uniqueImports.Select(import => MetadataReference.CreateFromFile(
-                    System.IO.Path.Combine(dllPath, import)));
+            List<MetadataReference> references = new List<MetadataReference>();
+            try
+            {
+                string dllPath = GetReferenceAssembliesPath();
+                foreach (string import in uniqueImports)
+                {
+                    references.Add(MetadataReference.CreateFromFile(System.IO.Path.Combine(
+                                                                        dllPath, import)));
+                }
+            }
+            catch (Exception e)
+            {
+                throw new CodeRunnerException(e.Message, e);
+            }
 
             var compilationOptions = new VisualBasicCompilationOptions(
                 OutputKind.ConsoleApplication,

--- a/DotNetEditor/DotNetEditor.csproj
+++ b/DotNetEditor/DotNetEditor.csproj
@@ -146,8 +146,8 @@
       <HintPath>..\packages\System.Threading.Thread.4.3.0\lib\net46\System.Threading.Thread.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    <Reference Include="System.ValueTuple, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Windows.Forms" />

--- a/DotNetEditor/DotNetEditor.csproj
+++ b/DotNetEditor/DotNetEditor.csproj
@@ -202,6 +202,7 @@
     <Compile Include="AvalonUtils\AvalonRichTextBox.cs" />
     <Compile Include="AvalonUtils\PixelSnapper.cs" />
     <Compile Include="CodeRunner\CodeRunnerBase.cs" />
+    <Compile Include="CodeRunner\CodeRunnerException.cs" />
     <Compile Include="CodeRunner\CSCodeRunner.cs" />
     <Compile Include="ConsoleColorScheme.cs" />
     <Compile Include="ConsoleUtil.cs" />
@@ -299,12 +300,12 @@
     <Resource Include="TextData\aboutbox.txt" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Fody.2.0.7\build\netstandard1.4\Fody.targets" Condition="Exists('..\packages\Fody.2.0.7\build\netstandard1.4\Fody.targets')" />
+  <Import Project="..\packages\Fody.2.0.6\build\netstandard1.4\Fody.targets" Condition="Exists('..\packages\Fody.2.0.6\build\netstandard1.4\Fody.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Fody.2.0.7\build\netstandard1.4\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.2.0.7\build\netstandard1.4\Fody.targets'))" />
+    <Error Condition="!Exists('..\packages\Fody.2.0.6\build\netstandard1.4\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.2.0.6\build\netstandard1.4\Fody.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/DotNetEditor/DotNetEditor.csproj
+++ b/DotNetEditor/DotNetEditor.csproj
@@ -300,12 +300,12 @@
     <Resource Include="TextData\aboutbox.txt" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Fody.2.0.6\build\netstandard1.4\Fody.targets" Condition="Exists('..\packages\Fody.2.0.6\build\netstandard1.4\Fody.targets')" />
+  <Import Project="..\packages\Fody.2.0.7\build\netstandard1.4\Fody.targets" Condition="Exists('..\packages\Fody.2.0.7\build\netstandard1.4\Fody.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Fody.2.0.6\build\netstandard1.4\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.2.0.6\build\netstandard1.4\Fody.targets'))" />
+    <Error Condition="!Exists('..\packages\Fody.2.0.7\build\netstandard1.4\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.2.0.7\build\netstandard1.4\Fody.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/DotNetEditor/packages.config
+++ b/DotNetEditor/packages.config
@@ -42,7 +42,7 @@
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net461" />
   <package id="System.Threading.Tasks.Parallel" version="4.3.0" targetFramework="net461" />
   <package id="System.Threading.Thread" version="4.3.0" targetFramework="net461" />
-  <package id="System.ValueTuple" version="4.3.0" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.3.1" targetFramework="net461" />
   <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net461" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net461" />
   <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="net461" />

--- a/DotNetEditor/packages.config
+++ b/DotNetEditor/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="AvalonEdit" version="5.0.3" targetFramework="net452" />
   <package id="Costura.Fody" version="1.4.1" targetFramework="net461" developmentDependency="true" />
-  <package id="Fody" version="2.0.7" targetFramework="net461" developmentDependency="true" />
+  <package id="Fody" version="2.0.6" targetFramework="net461" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.Common" version="2.1.0" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.Compilers" version="2.1.0" targetFramework="net461" />

--- a/DotNetEditor/packages.config
+++ b/DotNetEditor/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="AvalonEdit" version="5.0.3" targetFramework="net452" />
   <package id="Costura.Fody" version="1.4.1" targetFramework="net461" developmentDependency="true" />
-  <package id="Fody" version="2.0.6" targetFramework="net461" developmentDependency="true" />
+  <package id="Fody" version="2.0.7" targetFramework="net461" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.Common" version="2.1.0" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.Compilers" version="2.1.0" targetFramework="net461" />


### PR DESCRIPTION
Added automatic searching for .NET referenced assembly directory.
Show error messages instead of crash if a reference cannot be found.

Also update dependencies.