### PR TITLE
Some refactoring of AvalonRichTextBox

### DIFF
--- a/DotNetEditor/AvalonUtils/AvalonCodeRunnerOutput.cs
+++ b/DotNetEditor/AvalonUtils/AvalonCodeRunnerOutput.cs
@@ -11,10 +11,10 @@ using System.Windows.Media;
 
 namespace DotNetEditor
 {
-    /// <summary>
-    /// Interaction logic for AvalonRichTextBox.xaml
-    /// </summary>
-    public class AvalonRichTextBox : ICSharpCode.AvalonEdit.TextEditor
+    // This is the output area of a code runner, which is a customized AvalonEdit.TextEditor control
+    // with the ability to store formatting information with text.
+    public class AvalonCodeRunnerOutput :
+        ICSharpCode.AvalonEdit.TextEditor, CodeRunner.ICodeRunnerOutput
     {
         private class TextFormat : TextSegment
         {
@@ -136,14 +136,14 @@ namespace DotNetEditor
 
         private TextSegmentCollection<TextFormat> formatInfo;
 
-        public AvalonRichTextBox()
+        public AvalonCodeRunnerOutput()
         {
             formatInfo = new TextSegmentCollection<TextFormat>(Document);
             TextArea.TextView.LineTransformers.Add(new RTBColorizer(formatInfo));
             TextArea.TextView.BackgroundRenderers.Add(new RTBBackgroundRenderer(formatInfo));
         }
 
-        public void SetStyle(int startOffset, int endOffset,
+        private void SetStyle(int startOffset, int endOffset,
             Color foregroundColor, Color backgroundColor, bool? IsBold, bool? IsItalic)
         {
             TextFormat fmt = new TextFormat();
@@ -157,7 +157,7 @@ namespace DotNetEditor
             formatInfo.Add(fmt);
         }
 
-
+        #region ICodeRunnerOutput
         public void AppendTextWithStyle(string text, Color foregroundColor, Color backgroundColor,
             bool? isBold, bool? isItalic)
         {
@@ -165,5 +165,15 @@ namespace DotNetEditor
             AppendText(text);
             SetStyle(start, Text.Length, foregroundColor, backgroundColor, isBold, isItalic);
         }
+
+        // void AppendText(string text);  (already implemented by AvalonEdit.TextEditor)
+
+        // void Clear();  (already implemented by AvalonEdit.TextEditor)
+
+        public bool IsEmpty()
+        {
+            return !(Document?.TextLength > 0);
+        }
+        #endregion
     }
 }

--- a/DotNetEditor/CodeRunner/CSCodeRunner.cs
+++ b/DotNetEditor/CodeRunner/CSCodeRunner.cs
@@ -12,7 +12,7 @@ namespace DotNetEditor.CodeRunner
 {
     class CSCodeRunner : CodeRunnerBase
     {
-        public CSCodeRunner(string code, string inputData, AvalonRichTextBox outputArea)
+        public CSCodeRunner(string code, string inputData, AvalonCodeRunnerOutput outputArea)
             : base(code, inputData, outputArea)
         {
         }

--- a/DotNetEditor/CodeRunner/ICodeRunnerOutput.cs
+++ b/DotNetEditor/CodeRunner/ICodeRunnerOutput.cs
@@ -1,0 +1,24 @@
+﻿// Copyright 2017 Leung Wing-chung. All rights reserved.
+// Use of this source code is governed by a GPLv3 license that can be found in
+// the LICENSE file.
+
+using System.Windows.Media;
+
+namespace DotNetEditor.CodeRunner
+{
+    interface ICodeRunnerOutput
+    {
+        // Append text to the output with the specified style.
+        void AppendTextWithStyle(string text, Color foregroundColor, Color backgroundColor,
+                                 bool? isBold, bool? isItalic);
+
+        // Append text to the output with the default style.
+        void AppendText(string text);
+
+        // Remove all text and style from the output.
+        void Clear();
+
+        // Return if the output is empty.
+        bool IsEmpty();
+    }
+}

--- a/DotNetEditor/CodeRunner/VBCodeRunner.cs
+++ b/DotNetEditor/CodeRunner/VBCodeRunner.cs
@@ -13,7 +13,7 @@ namespace DotNetEditor.CodeRunner
 {
     class VBCodeRunner : CodeRunnerBase
     {
-        public VBCodeRunner(string code, string inputData, AvalonRichTextBox outputArea)
+        public VBCodeRunner(string code, string inputData, AvalonCodeRunnerOutput outputArea)
             : base(code, inputData, outputArea)
         {
         }

--- a/DotNetEditor/DotNetEditor.csproj
+++ b/DotNetEditor/DotNetEditor.csproj
@@ -199,11 +199,12 @@
       <DependentUpon>App.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="AvalonUtils\AvalonRichTextBox.cs" />
+    <Compile Include="AvalonUtils\AvalonCodeRunnerOutput.cs" />
     <Compile Include="AvalonUtils\PixelSnapper.cs" />
     <Compile Include="CodeRunner\CodeRunnerBase.cs" />
     <Compile Include="CodeRunner\CodeRunnerException.cs" />
     <Compile Include="CodeRunner\CSCodeRunner.cs" />
+    <Compile Include="CodeRunner\ICodeRunnerOutput.cs" />
     <Compile Include="ConsoleColorScheme.cs" />
     <Compile Include="ConsoleUtil.cs" />
     <Compile Include="Converters.cs" />

--- a/DotNetEditor/MainWindow.xaml
+++ b/DotNetEditor/MainWindow.xaml
@@ -56,7 +56,7 @@
                         CanExecute="About_CanExecute"
                         Executed="About_Executed" />
     </Window.CommandBindings>
-    
+
     <DockPanel>
         <ToolBar x:Name="toolBar"
                  DockPanel.Dock="Top">
@@ -168,15 +168,15 @@
                           Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"
                           ResizeBehavior="PreviousAndNext"
                           Margin="0,0,0,0" />
-            <local:AvalonRichTextBox x:Name="OutputArea"
-                                     Style="{StaticResource AvalonEdit}"
-                                     IsReadOnly="True"
-                                     Grid.Column="2"
-                                     Background="Black"
-                                     Foreground="Silver"
-                                     Margin="4,0,0,0">
+            <local:AvalonCodeRunnerOutput x:Name="OutputArea"
+                                          Style="{StaticResource AvalonEdit}"
+                                          IsReadOnly="True"
+                                          Grid.Column="2"
+                                          Background="Black"
+                                          Foreground="Silver"
+                                          Margin="4,0,0,0">
                 Output text...
-            </local:AvalonRichTextBox>
+            </local:AvalonCodeRunnerOutput>
         </Grid>
     </DockPanel>
 </Window>


### PR DESCRIPTION
Extract interface from AvalonRichTextBox for CodeRunnerBase. Now
CodeRunner can be tested without a concrete AvalonRichTextBox.

Also renamed AvalonRichTextBox to AvalonCodeRunnerOutput.