### PR TITLE
Fix class mode in CSCodeRunner and add tests

### DIFF
--- a/DotNetEditor.Tests/CodeRunnerTests.cs
+++ b/DotNetEditor.Tests/CodeRunnerTests.cs
@@ -1,0 +1,141 @@
+﻿// Copyright 2017 Leung Wing-chung. All rights reserved.
+// Use of this source code is governed by a GPLv3 license that can be found in
+// the LICENSE file.
+
+using DotNetEditor.CodeRunner;
+using Xunit;
+
+namespace DotNetEditor.Tests
+{
+    // Tests writing and/or capturing console output must not be run in parallel
+    // because they use the same console.
+    [Collection("Tests using the console")]
+    public class CodeRunnerTests
+    {
+        const string ConsoleOutputLine = Constants.ConsoleOutputLine;
+        const string DebugTraceLine = Constants.DebugTraceLine;
+        const string Separator = Constants.Separator;
+
+        [Fact]
+        public void RunVBCodeInsideSubMain()
+        {
+            const string code = "Console.WriteLine(123)";
+
+            TestCodeRunnerOutput output = new TestCodeRunnerOutput();
+            CodeRunnerBase runner = new VBCodeRunner(code, "", output);
+            Assert.True(runner.Run(), output.GetText());
+            Assert.Equal(ConsoleOutputLine + "123\r\n", output.GetText());
+        }
+
+        [Fact]
+        public void RunCSCodeInsideSubMain()
+        {
+            const string code = "Console.WriteLine(123);";
+
+            TestCodeRunnerOutput output = new TestCodeRunnerOutput();
+            CodeRunnerBase runner = new CSCodeRunner(code, "", output);
+            Assert.True(runner.Run(), output.GetText());
+            Assert.Equal(ConsoleOutputLine + "123\r\n", output.GetText());
+        }
+
+        [Fact]
+        public void RunVBCodeInModule()
+        {
+            const string code =
+                "Sub Main() \n Console.WriteLine(123) \n End Sub";
+
+            TestCodeRunnerOutput output = new TestCodeRunnerOutput();
+            CodeRunnerBase runner = new VBCodeRunner(code, "", output);
+            Assert.True(runner.Run(), output.GetText());
+            Assert.Equal(ConsoleOutputLine + "123\r\n", output.GetText());
+        }
+
+        [Fact]
+        public void RunCSCodeInClass()
+        {
+            const string code =
+                "static void Main() { Console.WriteLine(123); }";
+
+            TestCodeRunnerOutput output = new TestCodeRunnerOutput();
+            CodeRunnerBase runner = new CSCodeRunner(code, "", output);
+            Assert.True(runner.Run(), output.GetText());
+            Assert.Equal(ConsoleOutputLine + "123\r\n", output.GetText());
+        }
+
+        [Fact]
+        public void RunVBCodeAsFullFile()
+        {
+            const string code =
+                "Module Module1 \n Sub Main() \n Console.WriteLine(123) \n End Sub \n End Module";
+
+            TestCodeRunnerOutput output = new TestCodeRunnerOutput();
+            CodeRunnerBase runner = new VBCodeRunner(code, "", output);
+            Assert.True(runner.Run(), output.GetText());
+            Assert.Equal(ConsoleOutputLine + "123\r\n", output.GetText());
+        }
+
+        [Fact]
+        public void RunCSCodeAsFullFile()
+        {
+            const string code =
+                "using System; class Class1 { static void Main() { Console.WriteLine(123); } }";
+
+            TestCodeRunnerOutput output = new TestCodeRunnerOutput();
+            CodeRunnerBase runner = new CSCodeRunner(code, "", output);
+            Assert.True(runner.Run(), output.GetText());
+            Assert.Equal(ConsoleOutputLine + "123\r\n", output.GetText());
+        }
+
+        [Fact]
+        public void RunVBCodeWithDebugOutput()
+        {
+            const string code = "Debug.WriteLine(456) : Console.WriteLine(123)";
+
+            TestCodeRunnerOutput output = new TestCodeRunnerOutput();
+            CodeRunnerBase runner = new VBCodeRunner(code, "", output);
+            Assert.True(runner.Run(), output.GetText());
+            Assert.Equal(
+                ConsoleOutputLine + "123\r\n" + Separator + DebugTraceLine + "456\r\n",
+                output.GetText());
+        }
+
+        [Fact]
+        public void RunCSCodeWithDebugOutput()
+        {
+            const string code = "Debug.WriteLine(456); Console.WriteLine(123);";
+
+            TestCodeRunnerOutput output = new TestCodeRunnerOutput();
+            CodeRunnerBase runner = new CSCodeRunner(code, "", output);
+            Assert.True(runner.Run(), output.GetText());
+            Assert.Equal(
+                ConsoleOutputLine + "123\r\n" + Separator + DebugTraceLine + "456\r\n",
+                output.GetText());
+        }
+
+        [Fact]
+        public void RunVBCodeWithTraceOutput()
+        {
+            const string code = "Debug.WriteLine(456) : Console.WriteLine(123)";
+
+            TestCodeRunnerOutput output = new TestCodeRunnerOutput();
+            CodeRunnerBase runner = new VBCodeRunner(code, "", output);
+            Assert.True(runner.Run(), output.GetText());
+            Assert.Equal(
+                ConsoleOutputLine + "123\r\n" + Separator + DebugTraceLine + "456\r\n",
+                output.GetText());
+        }
+
+        [Fact]
+        public void RunCSCodeWithTraceOutput()
+        {
+            const string code = "Trace.WriteLine(456); Console.WriteLine(123);";
+
+            TestCodeRunnerOutput output = new TestCodeRunnerOutput();
+            CodeRunnerBase runner = new CSCodeRunner(code, "", output);
+            Assert.True(runner.Run(), output.GetText());
+            Assert.Equal(
+                ConsoleOutputLine + "123\r\n" + Separator + DebugTraceLine + "456\r\n",
+                output.GetText());
+        }
+    }
+}

--- a/DotNetEditor.Tests/DotNetEditor.Tests.csproj
+++ b/DotNetEditor.Tests/DotNetEditor.Tests.csproj
@@ -1,0 +1,111 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{683BCD42-80C6-4D29-B204-1BBF871CB42B}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>DotNetEditor.Tests</RootNamespace>
+    <AssemblyName>DotNetEditor.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="ICSharpCode.AvalonEdit, Version=5.0.3.0, Culture=neutral, PublicKeyToken=9cc39be672370310, processorArchitecture=MSIL">
+      <HintPath>..\packages\AvalonEdit.5.0.3\lib\Net40\ICSharpCode.AvalonEdit.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.assert.2.2.0\lib\netstandard1.1\xunit.assert.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.2.0\lib\netstandard1.1\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.execution.2.2.0\lib\net452\xunit.execution.desktop.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.runner.reporters.net452, Version=2.2.0.3545, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.runner.reporters.2.2.0\lib\net452\xunit.runner.reporters.net452.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.runner.utility.net452, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.runner.utility.2.2.0\lib\net452\xunit.runner.utility.net452.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="CodeRunnerTests.cs" />
+    <Compile Include="Constants.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestCodeRunnerOutput.cs" />
+    <Compile Include="TextWriterWithConsoleColorTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DotNetEditor\DotNetEditor.csproj">
+      <Project>{e54077c3-703e-4a13-9d01-382b30e8aaee}</Project>
+      <Name>DotNetEditor</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/DotNetEditor.Tests/Properties/AssemblyInfo.cs
+++ b/DotNetEditor.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("DotNetEditor.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("DotNetEditor.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("683bcd42-80c6-4d29-b204-1bbf871cb42b")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/DotNetEditor.Tests/TestCodeRunnerOutput.cs
+++ b/DotNetEditor.Tests/TestCodeRunnerOutput.cs
@@ -1,0 +1,101 @@
+﻿// Copyright 2017 Leung Wing-chung. All rights reserved.
+// Use of this source code is governed by a GPLv3 license that can be found in
+// the LICENSE file.
+
+using ICSharpCode.AvalonEdit.Document;
+using System.Text;
+using System.Windows.Media;
+using Xunit;
+
+namespace DotNetEditor.Tests
+{
+    public class TestCodeRunnerOutput : CodeRunner.ICodeRunnerOutput
+    {
+        public TestCodeRunnerOutput()
+        {
+            _text = new StringBuilder();
+            _format = new TextSegmentCollection<AvalonCodeRunnerOutput.TextFormat>();
+        }
+
+        public void AppendText(string text)
+        {
+            _text.Append(text);
+        }
+
+        public void AppendTextWithStyle(string text, Color foregroundColor, Color backgroundColor,
+                                        bool? isBold, bool? isItalic)
+        {
+            int startOffset = _text.Length;
+            _text.Append(text);
+            int endOffset = _text.Length;
+            AddFormatData(startOffset, endOffset, foregroundColor, backgroundColor, isBold, isItalic);
+        }
+
+        public string GetText()
+        {
+            return _text.ToString();
+        }
+
+        public void AssertTextFormat(int offset, Color? foregroundColor, Color? backgroundColor,
+            bool? IsBold, bool? IsItalic)
+        {
+            Color? actualForegroundColor = null;
+            Color? actualBackgroundColor = null;
+            bool actualIsBold = false;
+            bool actualIsItalic = false;
+            foreach (var segment in _format.FindSegmentsContaining(offset))
+            {
+                actualForegroundColor = segment.ForegroundColor;
+                actualBackgroundColor = segment.BackgroundColor;
+                actualIsBold = segment.IsBold ?? actualIsBold;
+                actualIsItalic = segment.IsItalic ?? actualIsItalic;
+            }
+
+            if (foregroundColor.HasValue)
+            {
+                Assert.Equal(foregroundColor, actualForegroundColor);
+            }
+            if (backgroundColor.HasValue)
+            {
+                Assert.Equal(backgroundColor, actualBackgroundColor);
+            }
+            if (IsBold.HasValue)
+            {
+                Assert.Equal(IsBold, actualIsBold);
+            }
+            if (IsItalic.HasValue)
+            {
+                Assert.Equal(IsItalic, actualIsItalic);
+            }
+            return;
+        }
+
+        public void Clear()
+        {
+            _text.Clear();
+            _format.Clear();
+        }
+
+        public bool IsEmpty()
+        {
+            return _text.Length == 0;
+        }
+
+        private void AddFormatData(int startOffset, int endOffset,
+            Color foregroundColor, Color backgroundColor, bool? IsBold, bool? IsItalic)
+        {
+            AvalonCodeRunnerOutput.TextFormat fmt = new AvalonCodeRunnerOutput.TextFormat();
+            fmt.StartOffset = startOffset;
+            fmt.EndOffset = endOffset;
+            fmt.ForegroundColor = foregroundColor;
+            fmt.BackgroundColor = backgroundColor;
+            fmt.IsBold = IsBold;
+            fmt.IsItalic = IsItalic;
+
+            _format.Add(fmt);
+        }
+
+        private StringBuilder _text;
+        private TextSegmentCollection<AvalonCodeRunnerOutput.TextFormat> _format;
+    }
+}

--- a/DotNetEditor.Tests/TextWriterWithConsoleColorTests.cs
+++ b/DotNetEditor.Tests/TextWriterWithConsoleColorTests.cs
@@ -1,0 +1,53 @@
+﻿// Copyright 2017 Leung Wing-chung. All rights reserved.
+// Use of this source code is governed by a GPLv3 license that can be found in
+// the LICENSE file.
+
+using DotNetEditor.CodeRunner;
+using System.Windows.Media;
+using Xunit;
+
+namespace DotNetEditor.Tests
+{
+    // Tests writing and/or capturing console output must not be run in parallel
+    // because they use the same console.
+    [Collection("Tests using the console")]
+    public class TextWriterWithConsoleColorTests
+    {
+        const string ConsoleOutputLine = Constants.ConsoleOutputLine;
+
+        [Fact]
+        public void TextWriterWithConsoleColor()
+        {
+            const string code = @"
+Console.ForegroundColor = ConsoleColor.Red;
+Console.Write(12);
+Console.BackgroundColor = ConsoleColor.Green;
+Console.Write(34);
+Console.ForegroundColor = ConsoleColor.Blue;
+Console.Write(56);
+Console.BackgroundColor = ConsoleColor.White;
+Console.Write(78);
+";
+
+            TestCodeRunnerOutput output = new TestCodeRunnerOutput();
+            CodeRunnerBase runner = new CSCodeRunner(code, "", output);
+            Assert.True(runner.Run(), output.GetText());
+            Assert.Equal(ConsoleOutputLine + "12345678", output.GetText());
+
+            Color red = ConsoleColorScheme.DefaultColorScheme.Colors[12];
+            Color green = ConsoleColorScheme.DefaultColorScheme.Colors[10];
+            Color blue = ConsoleColorScheme.DefaultColorScheme.Colors[9];
+            Color white = ConsoleColorScheme.DefaultColorScheme.Colors[15];
+
+            int basePos = ConsoleOutputLine.Length;
+            output.AssertTextFormat(basePos, red, null, null, null);
+            output.AssertTextFormat(basePos + 1, red, null, null, null);
+            output.AssertTextFormat(basePos + 2, red, green, null, null);
+            output.AssertTextFormat(basePos + 3, red, green, null, null);
+            output.AssertTextFormat(basePos + 4, blue, green, null, null);
+            output.AssertTextFormat(basePos + 5, blue, green, null, null);
+            output.AssertTextFormat(basePos + 6, blue, white, null, null);
+            output.AssertTextFormat(basePos + 7, blue, white, null, null);
+        }
+    }
+}

--- a/DotNetEditor.Tests/app.config
+++ b/DotNetEditor.Tests/app.config
@@ -1,0 +1,43 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Security.Cryptography.Algorithms" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.FileSystem" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.FileSystem.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Security.Cryptography.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Xml.XPath.XDocument" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.FileVersionInfo" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/DotNetEditor.Tests/constants.cs
+++ b/DotNetEditor.Tests/constants.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DotNetEditor.Tests
+{
+    static class Constants
+    {
+        public const string ConsoleOutputLine = " --- Console output --- \n";
+        public const string DebugTraceLine = " --- Debug/trace output --- \n";
+        public const string Separator = "\n\n";
+    }
+}

--- a/DotNetEditor.Tests/packages.config
+++ b/DotNetEditor.Tests/packages.config
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="AvalonEdit" version="5.0.3" targetFramework="net461" />
+  <package id="xunit" version="2.2.0" targetFramework="net452" />
+  <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
+  <package id="xunit.assert" version="2.2.0" targetFramework="net452" />
+  <package id="xunit.core" version="2.2.0" targetFramework="net452" />
+  <package id="xunit.extensibility.core" version="2.2.0" targetFramework="net452" />
+  <package id="xunit.extensibility.execution" version="2.2.0" targetFramework="net452" />
+  <package id="xunit.runner.console" version="2.2.0" targetFramework="net452" developmentDependency="true" />
+  <package id="xunit.runner.reporters" version="2.2.0" targetFramework="net452" />
+  <package id="xunit.runner.utility" version="2.2.0" targetFramework="net452" />
+  <package id="xunit.runner.visualstudio" version="2.2.0" targetFramework="net452" developmentDependency="true" />
+</packages>

--- a/DotNetEditor.sln
+++ b/DotNetEditor.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetEditor", "DotNetEditor\DotNetEditor.csproj", "{E54077C3-703E-4A13-9D01-382B30E8AAEE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetEditor.Tests", "DotNetEditor.Tests\DotNetEditor.Tests.csproj", "{683BCD42-80C6-4D29-B204-1BBF871CB42B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{E54077C3-703E-4A13-9D01-382B30E8AAEE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E54077C3-703E-4A13-9D01-382B30E8AAEE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E54077C3-703E-4A13-9D01-382B30E8AAEE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{683BCD42-80C6-4D29-B204-1BBF871CB42B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{683BCD42-80C6-4D29-B204-1BBF871CB42B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{683BCD42-80C6-4D29-B204-1BBF871CB42B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{683BCD42-80C6-4D29-B204-1BBF871CB42B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/DotNetEditor/AvalonUtils/AvalonCodeRunnerOutput.cs
+++ b/DotNetEditor/AvalonUtils/AvalonCodeRunnerOutput.cs
@@ -6,17 +6,20 @@ using ICSharpCode.AvalonEdit.Document;
 using ICSharpCode.AvalonEdit.Rendering;
 using System;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Windows;
 using System.Windows.Media;
+
+[assembly: InternalsVisibleToAttribute("DotNetEditor.Tests")]
 
 namespace DotNetEditor
 {
     // This is the output area of a code runner, which is a customized AvalonEdit.TextEditor control
     // with the ability to store formatting information with text.
-    public class AvalonCodeRunnerOutput :
+    class AvalonCodeRunnerOutput :
         ICSharpCode.AvalonEdit.TextEditor, CodeRunner.ICodeRunnerOutput
     {
-        private class TextFormat : TextSegment
+        internal class TextFormat : TextSegment
         {
             public Color ForegroundColor = Brushes.LightGray.Color;
             public Color BackgroundColor = Brushes.Black.Color;

--- a/DotNetEditor/CodeRunner/CSCodeRunner.cs
+++ b/DotNetEditor/CodeRunner/CSCodeRunner.cs
@@ -7,12 +7,15 @@ using Microsoft.CodeAnalysis.CSharp;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleToAttribute("DotNetEditor.Tests")]
 
 namespace DotNetEditor.CodeRunner
 {
     class CSCodeRunner : CodeRunnerBase
     {
-        public CSCodeRunner(string code, string inputData, AvalonCodeRunnerOutput outputArea)
+        public CSCodeRunner(string code, string inputData, ICodeRunnerOutput outputArea)
             : base(code, inputData, outputArea)
         {
         }
@@ -53,10 +56,10 @@ namespace DotNetEditor.CodeRunner
         {
             string[] templates =
             {
-                // the raw program
-                "{0}",
                 // the program put inside a class
                 "{1} class Program {{ {0} }}",
+                // the raw program
+                "{0}",
                 // the program put inside Main function
                 "{1} class Program {{ static void Main(string[] args) {{ {0} }} }}"
             };

--- a/DotNetEditor/CodeRunner/CodeRunnerBase.cs
+++ b/DotNetEditor/CodeRunner/CodeRunnerBase.cs
@@ -9,8 +9,11 @@ using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Brushes = System.Windows.Media.Brushes;
 using Color = System.Windows.Media.Color;
+
+[assembly: InternalsVisibleToAttribute("DotNetEditor.Tests")]
 
 namespace DotNetEditor.CodeRunner
 {
@@ -183,7 +186,7 @@ namespace DotNetEditor.CodeRunner
 
                 System.Diagnostics.Debug.WriteLine(
                     "Code being compiled with errors:\n" +
-                    emitResult.Diagnostics[0].Location.SourceTree.GetText().ToString());
+                    emitResult.Diagnostics[0].Location.SourceTree?.GetText() ?? "unknown");
 
                 return false;
             }

--- a/DotNetEditor/CodeRunner/ICodeRunnerOutput.cs
+++ b/DotNetEditor/CodeRunner/ICodeRunnerOutput.cs
@@ -2,7 +2,10 @@
 // Use of this source code is governed by a GPLv3 license that can be found in
 // the LICENSE file.
 
+using System.Runtime.CompilerServices;
 using System.Windows.Media;
+
+[assembly: InternalsVisibleToAttribute("DotNetEditor.Tests")]
 
 namespace DotNetEditor.CodeRunner
 {

--- a/DotNetEditor/CodeRunner/VBCodeRunner.cs
+++ b/DotNetEditor/CodeRunner/VBCodeRunner.cs
@@ -8,12 +8,15 @@ using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleToAttribute("DotNetEditor.Tests")]
 
 namespace DotNetEditor.CodeRunner
 {
     class VBCodeRunner : CodeRunnerBase
     {
-        public VBCodeRunner(string code, string inputData, AvalonCodeRunnerOutput outputArea)
+        public VBCodeRunner(string code, string inputData, ICodeRunnerOutput outputArea)
             : base(code, inputData, outputArea)
         {
         }

--- a/DotNetEditor/ConsoleColorScheme.cs
+++ b/DotNetEditor/ConsoleColorScheme.cs
@@ -3,7 +3,10 @@
 // the LICENSE file.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Windows.Media;
+
+[assembly: InternalsVisibleToAttribute("DotNetEditor.Tests")]
 
 namespace DotNetEditor
 {


### PR DESCRIPTION
The code "static void Main() { Console.Write(123); }" failed
compilation because a wrong template is selected. This commit
fix the bug by changing the order of the templates used.

Tests are also added to verify correctness of compilation of
all implemented cases.