### PR TITLE
Make TextWriterWithConsoleColor skippable

### DIFF
--- a/DotNetEditor.Tests/DotNetEditor.Tests.csproj
+++ b/DotNetEditor.Tests/DotNetEditor.Tests.csproj
@@ -78,6 +78,14 @@
     <Compile Include="CodeRunnerTests.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SkippableTest\SkippableFactAttribute.cs" />
+    <Compile Include="SkippableTest\SkippableTheoryAttribute.cs" />
+    <Compile Include="SkippableTest\SkipTestException.cs" />
+    <Compile Include="SkippableTest\XunitExtensions\SkippableFactDiscoverer.cs" />
+    <Compile Include="SkippableTest\XunitExtensions\SkippableFactMessageBus.cs" />
+    <Compile Include="SkippableTest\XunitExtensions\SkippableFactTestCase.cs" />
+    <Compile Include="SkippableTest\XunitExtensions\SkippableTheoryDiscoverer.cs" />
+    <Compile Include="SkippableTest\XunitExtensions\SkippableTheoryTestCase.cs" />
     <Compile Include="TestCodeRunnerOutput.cs" />
     <Compile Include="TextWriterWithConsoleColorTests.cs" />
   </ItemGroup>

--- a/DotNetEditor.Tests/SkippableTest/SkipTestException.cs
+++ b/DotNetEditor.Tests/SkippableTest/SkipTestException.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace SkippableTest
+{
+    public class SkipTestException : Exception
+    {
+        public SkipTestException(string reason)
+            : base(reason) { }
+    }
+}

--- a/DotNetEditor.Tests/SkippableTest/SkippableFactAttribute.cs
+++ b/DotNetEditor.Tests/SkippableTest/SkippableFactAttribute.cs
@@ -1,0 +1,9 @@
+﻿using Xunit;
+using Xunit.Sdk;
+
+namespace SkippableTest
+{
+    [XunitTestCaseDiscoverer("SkippableTest.XunitExtensions.SkippableFactDiscoverer",
+        "DotNetEditor.Tests")]
+    public class SkippableFactAttribute : FactAttribute { }
+}

--- a/DotNetEditor.Tests/SkippableTest/SkippableTheoryAttribute.cs
+++ b/DotNetEditor.Tests/SkippableTest/SkippableTheoryAttribute.cs
@@ -1,0 +1,9 @@
+﻿using Xunit;
+using Xunit.Sdk;
+
+namespace SkippableTest
+{
+    [XunitTestCaseDiscoverer("SkippableTest.XunitExtensions.SkippableTheoryDiscoverer",
+        "DotNetEditor.Tests")]
+    public class SkippableTheoryAttribute : TheoryAttribute { }
+}

--- a/DotNetEditor.Tests/SkippableTest/XunitExtensions/SkippableFactDiscoverer.cs
+++ b/DotNetEditor.Tests/SkippableTest/XunitExtensions/SkippableFactDiscoverer.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace SkippableTest.XunitExtensions
+{
+    public class SkippableFactDiscoverer : IXunitTestCaseDiscoverer
+    {
+        readonly IMessageSink diagnosticMessageSink;
+
+        public SkippableFactDiscoverer(IMessageSink diagnosticMessageSink)
+        {
+            this.diagnosticMessageSink = diagnosticMessageSink;
+        }
+
+        public IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
+        {
+            yield return new SkippableFactTestCase(diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod);
+        }
+    }
+}

--- a/DotNetEditor.Tests/SkippableTest/XunitExtensions/SkippableFactMessageBus.cs
+++ b/DotNetEditor.Tests/SkippableTest/XunitExtensions/SkippableFactMessageBus.cs
@@ -1,0 +1,37 @@
+﻿using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace SkippableTest.XunitExtensions
+{
+    public class SkippableFactMessageBus : IMessageBus
+    {
+        readonly IMessageBus innerBus;
+
+        public SkippableFactMessageBus(IMessageBus innerBus)
+        {
+            this.innerBus = innerBus;
+        }
+
+        public int DynamicallySkippedTestCount { get; private set; }
+
+        public void Dispose() { }
+
+        public bool QueueMessage(IMessageSinkMessage message)
+        {
+            var testFailed = message as ITestFailed;
+            if (testFailed != null)
+            {
+                var exceptionType = testFailed.ExceptionTypes.FirstOrDefault();
+                if (exceptionType == typeof(SkipTestException).FullName)
+                {
+                    DynamicallySkippedTestCount++;
+                    return innerBus.QueueMessage(new TestSkipped(testFailed.Test, testFailed.Messages.FirstOrDefault()));
+                }
+            }
+
+            // Nothing we care about, send it on its way
+            return innerBus.QueueMessage(message);
+        }
+    }
+}

--- a/DotNetEditor.Tests/SkippableTest/XunitExtensions/SkippableFactTestCase.cs
+++ b/DotNetEditor.Tests/SkippableTest/XunitExtensions/SkippableFactTestCase.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace SkippableTest.XunitExtensions
+{
+    public class SkippableFactTestCase : XunitTestCase
+    {
+        [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+        public SkippableFactTestCase() { }
+
+        public SkippableFactTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, ITestMethod testMethod, object[] testMethodArguments = null)
+            : base(diagnosticMessageSink, defaultMethodDisplay, testMethod, testMethodArguments) { }
+
+        public override async Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink,
+                                                        IMessageBus messageBus,
+                                                        object[] constructorArguments,
+                                                        ExceptionAggregator aggregator,
+                                                        CancellationTokenSource cancellationTokenSource)
+        {
+            var skipMessageBus = new SkippableFactMessageBus(messageBus);
+            var result = await base.RunAsync(diagnosticMessageSink, skipMessageBus, constructorArguments, aggregator, cancellationTokenSource);
+            if (skipMessageBus.DynamicallySkippedTestCount > 0)
+            {
+                result.Failed -= skipMessageBus.DynamicallySkippedTestCount;
+                result.Skipped += skipMessageBus.DynamicallySkippedTestCount;
+            }
+
+            return result;
+        }
+    }
+}

--- a/DotNetEditor.Tests/SkippableTest/XunitExtensions/SkippableTheoryDiscoverer.cs
+++ b/DotNetEditor.Tests/SkippableTest/XunitExtensions/SkippableTheoryDiscoverer.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace SkippableTest.XunitExtensions
+{
+    public class SkippableTheoryDiscoverer : IXunitTestCaseDiscoverer
+    {
+        readonly IMessageSink diagnosticMessageSink;
+        readonly TheoryDiscoverer theoryDiscoverer;
+
+        public SkippableTheoryDiscoverer(IMessageSink diagnosticMessageSink)
+        {
+            this.diagnosticMessageSink = diagnosticMessageSink;
+
+            theoryDiscoverer = new TheoryDiscoverer(diagnosticMessageSink);
+        }
+
+        public IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
+        {
+            var defaultMethodDisplay = discoveryOptions.MethodDisplayOrDefault();
+
+            // Unlike fact discovery, the underlying algorithm for theories is complex, so we let the theory discoverer
+            // do its work, and do a little on-the-fly conversion into our own test cases.
+            return theoryDiscoverer.Discover(discoveryOptions, testMethod, factAttribute)
+                                   .Select(testCase => testCase is XunitTheoryTestCase
+                                                           ? (IXunitTestCase)new SkippableTheoryTestCase(diagnosticMessageSink, defaultMethodDisplay, testCase.TestMethod)
+                                                           : new SkippableFactTestCase(diagnosticMessageSink, defaultMethodDisplay, testCase.TestMethod, testCase.TestMethodArguments));
+        }
+    }
+}

--- a/DotNetEditor.Tests/SkippableTest/XunitExtensions/SkippableTheoryTestCase.cs
+++ b/DotNetEditor.Tests/SkippableTest/XunitExtensions/SkippableTheoryTestCase.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace SkippableTest.XunitExtensions
+{
+    public class SkippableTheoryTestCase : XunitTheoryTestCase
+    {
+        [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+        public SkippableTheoryTestCase() { }
+
+        public SkippableTheoryTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, ITestMethod testMethod)
+            : base(diagnosticMessageSink, defaultMethodDisplay, testMethod) { }
+
+        public override async Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink,
+                                                        IMessageBus messageBus,
+                                                        object[] constructorArguments,
+                                                        ExceptionAggregator aggregator,
+                                                        CancellationTokenSource cancellationTokenSource)
+        {
+            // Duplicated code from SkippableFactTestCase. I'm sure we could find a way to de-dup with some thought.
+            var skipMessageBus = new SkippableFactMessageBus(messageBus);
+            var result = await base.RunAsync(diagnosticMessageSink, skipMessageBus, constructorArguments, aggregator, cancellationTokenSource);
+            if (skipMessageBus.DynamicallySkippedTestCount > 0)
+            {
+                result.Failed -= skipMessageBus.DynamicallySkippedTestCount;
+                result.Skipped += skipMessageBus.DynamicallySkippedTestCount;
+            }
+
+            return result;
+        }
+    }
+}

--- a/DotNetEditor.Tests/TextWriterWithConsoleColorTests.cs
+++ b/DotNetEditor.Tests/TextWriterWithConsoleColorTests.cs
@@ -36,6 +36,8 @@ namespace DotNetEditor.Tests
                     throw new SkipTestException(noConsoleColor);
                 }
             }
+
+            Console.ResetColor();
         }
 
         [SkippableFact]

--- a/DotNetEditor.Tests/TextWriterWithConsoleColorTests.cs
+++ b/DotNetEditor.Tests/TextWriterWithConsoleColorTests.cs
@@ -3,6 +3,8 @@
 // the LICENSE file.
 
 using DotNetEditor.CodeRunner;
+using SkippableTest;
+using System;
 using System.Windows.Media;
 using Xunit;
 
@@ -15,10 +17,31 @@ namespace DotNetEditor.Tests
     {
         const string ConsoleOutputLine = Constants.ConsoleOutputLine;
 
-        [Fact]
+        private void SkipTestIfNoConsoleColor()
+        {
+            const string noConsoleColor = "Console color not available.";
+
+            ConsoleColor[] colorList = (ConsoleColor[]) Enum.GetValues(typeof(ConsoleColor));
+            foreach (var color in colorList)
+            {
+                Console.ForegroundColor = color;
+                if (Console.ForegroundColor != color)
+                {
+                    throw new SkipTestException(noConsoleColor);
+                }
+
+                Console.BackgroundColor = color;
+                if (Console.BackgroundColor != color)
+                {
+                    throw new SkipTestException(noConsoleColor);
+                }
+            }
+        }
+
+        [SkippableFact]
         public void TextWriterWithConsoleColor()
         {
-            ConsoleUtil.CreateHiddenConsoleWindowIfNotExists();
+            SkipTestIfNoConsoleColor();
 
             const string code = @"
 Console.ForegroundColor = ConsoleColor.Red;

--- a/DotNetEditor.Tests/TextWriterWithConsoleColorTests.cs
+++ b/DotNetEditor.Tests/TextWriterWithConsoleColorTests.cs
@@ -18,6 +18,8 @@ namespace DotNetEditor.Tests
         [Fact]
         public void TextWriterWithConsoleColor()
         {
+            ConsoleUtil.CreateHiddenConsoleWindowIfNotExists();
+
             const string code = @"
 Console.ForegroundColor = ConsoleColor.Red;
 Console.Write(12);


### PR DESCRIPTION
* Add SkippableFact and SkippableTheory from xUnit examples.
* TextWriterWithConsoleColor now skips if Console.ForegroundColor is not usable.