### PR TITLE
Update skippable tests to xUnit 2.4

### DIFF
--- a/DotNetEditor.Tests/SkippableTest/XunitExtensions/SkippableFactDiscoverer.cs
+++ b/DotNetEditor.Tests/SkippableTest/XunitExtensions/SkippableFactDiscoverer.cs
@@ -13,9 +13,15 @@ namespace SkippableTest.XunitExtensions
             this.diagnosticMessageSink = diagnosticMessageSink;
         }
 
-        public IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
+        public IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions,
+                                                    ITestMethod testMethod,
+                                                    IAttributeInfo factAttribute)
         {
-            yield return new SkippableFactTestCase(diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod);
+            yield return new SkippableFactTestCase(
+                diagnosticMessageSink,
+                discoveryOptions.MethodDisplayOrDefault(),
+                discoveryOptions.MethodDisplayOptionsOrDefault(),
+                testMethod);
         }
     }
 }

--- a/DotNetEditor.Tests/SkippableTest/XunitExtensions/SkippableFactTestCase.cs
+++ b/DotNetEditor.Tests/SkippableTest/XunitExtensions/SkippableFactTestCase.cs
@@ -11,17 +11,25 @@ namespace SkippableTest.XunitExtensions
         [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
         public SkippableFactTestCase() { }
 
-        public SkippableFactTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, ITestMethod testMethod, object[] testMethodArguments = null)
-            : base(diagnosticMessageSink, defaultMethodDisplay, testMethod, testMethodArguments) { }
+        public SkippableFactTestCase(IMessageSink diagnosticMessageSink,
+                                     TestMethodDisplay defaultMethodDisplay,
+                                     TestMethodDisplayOptions defaultMethodDisplayOptions,
+                                     ITestMethod testMethod,
+                                     object[] testMethodArguments = null)
+            : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions,
+                   testMethod, testMethodArguments) { }
 
-        public override async Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink,
-                                                        IMessageBus messageBus,
-                                                        object[] constructorArguments,
-                                                        ExceptionAggregator aggregator,
-                                                        CancellationTokenSource cancellationTokenSource)
+        public override async Task<RunSummary>
+            RunAsync(IMessageSink diagnosticMessageSink,
+                     IMessageBus messageBus,
+                     object[] constructorArguments,
+                     ExceptionAggregator aggregator,
+                     CancellationTokenSource cancellationTokenSource)
         {
             var skipMessageBus = new SkippableFactMessageBus(messageBus);
-            var result = await base.RunAsync(diagnosticMessageSink, skipMessageBus, constructorArguments, aggregator, cancellationTokenSource);
+            var result = await base.RunAsync(diagnosticMessageSink, skipMessageBus,
+                                             constructorArguments, aggregator,
+                                             cancellationTokenSource);
             if (skipMessageBus.DynamicallySkippedTestCount > 0)
             {
                 result.Failed -= skipMessageBus.DynamicallySkippedTestCount;

--- a/DotNetEditor.Tests/SkippableTest/XunitExtensions/SkippableTheoryDiscoverer.cs
+++ b/DotNetEditor.Tests/SkippableTest/XunitExtensions/SkippableTheoryDiscoverer.cs
@@ -17,16 +17,28 @@ namespace SkippableTest.XunitExtensions
             theoryDiscoverer = new TheoryDiscoverer(diagnosticMessageSink);
         }
 
-        public IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
+        public IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions,
+                                                    ITestMethod testMethod,
+                                                    IAttributeInfo factAttribute)
         {
             var defaultMethodDisplay = discoveryOptions.MethodDisplayOrDefault();
+            var defaultMethodDisplayOptions = discoveryOptions.MethodDisplayOptionsOrDefault();
 
-            // Unlike fact discovery, the underlying algorithm for theories is complex, so we let the theory discoverer
-            // do its work, and do a little on-the-fly conversion into our own test cases.
-            return theoryDiscoverer.Discover(discoveryOptions, testMethod, factAttribute)
-                                   .Select(testCase => testCase is XunitTheoryTestCase
-                                                           ? (IXunitTestCase)new SkippableTheoryTestCase(diagnosticMessageSink, defaultMethodDisplay, testCase.TestMethod)
-                                                           : new SkippableFactTestCase(diagnosticMessageSink, defaultMethodDisplay, testCase.TestMethod, testCase.TestMethodArguments));
+            // Unlike fact discovery, the underlying algorithm for theories is complex, so we let
+            // the theory discoverer do its work, and do a little on-the-fly conversion into our own
+            // test cases.
+            return theoryDiscoverer
+                       .Discover(discoveryOptions, testMethod, factAttribute)
+                       .Select(testCase => (
+                           testCase is XunitTheoryTestCase
+                               ? (IXunitTestCase)new SkippableTheoryTestCase(
+                                   diagnosticMessageSink, defaultMethodDisplay,
+                                   defaultMethodDisplayOptions, testCase.TestMethod)
+                               : new SkippableFactTestCase(
+                                   diagnosticMessageSink, defaultMethodDisplay,
+                                   defaultMethodDisplayOptions, testCase.TestMethod,
+                                   testCase.TestMethodArguments))
+                       );
         }
     }
 }

--- a/DotNetEditor.Tests/SkippableTest/XunitExtensions/SkippableTheoryTestCase.cs
+++ b/DotNetEditor.Tests/SkippableTest/XunitExtensions/SkippableTheoryTestCase.cs
@@ -11,18 +11,26 @@ namespace SkippableTest.XunitExtensions
         [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
         public SkippableTheoryTestCase() { }
 
-        public SkippableTheoryTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, ITestMethod testMethod)
-            : base(diagnosticMessageSink, defaultMethodDisplay, testMethod) { }
+        public SkippableTheoryTestCase(IMessageSink diagnosticMessageSink,
+                                       TestMethodDisplay defaultMethodDisplay,
+                                       TestMethodDisplayOptions defaultMethodDisplayOptions,
+                                       ITestMethod testMethod)
+            : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions,
+                   testMethod) { }
 
-        public override async Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink,
-                                                        IMessageBus messageBus,
-                                                        object[] constructorArguments,
-                                                        ExceptionAggregator aggregator,
-                                                        CancellationTokenSource cancellationTokenSource)
+        public override async Task<RunSummary>
+            RunAsync(IMessageSink diagnosticMessageSink,
+                     IMessageBus messageBus,
+                     object[] constructorArguments,
+                     ExceptionAggregator aggregator,
+                     CancellationTokenSource cancellationTokenSource)
         {
-            // Duplicated code from SkippableFactTestCase. I'm sure we could find a way to de-dup with some thought.
+            // Duplicated code from SkippableFactTestCase. I'm sure we could find a way to de-dup
+            // with some thought.
             var skipMessageBus = new SkippableFactMessageBus(messageBus);
-            var result = await base.RunAsync(diagnosticMessageSink, skipMessageBus, constructorArguments, aggregator, cancellationTokenSource);
+            var result = await base.RunAsync(diagnosticMessageSink, skipMessageBus,
+                                             constructorArguments, aggregator,
+                                             cancellationTokenSource);
             if (skipMessageBus.DynamicallySkippedTestCount > 0)
             {
                 result.Failed -= skipMessageBus.DynamicallySkippedTestCount;


### PR DESCRIPTION
SkippableFact and SkippableTheory are updated because the current API is
deprecated. Also reformatted the code to 100 columns.

Note: original code comes from xUnit examples.